### PR TITLE
fixup info.rkt license syntax

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -13,4 +13,4 @@
 (define compile-omit-paths '("scripts/unbound-id.rkt"
                              "scripts/unbound-id-not-skipped.rkt"))
 (define test-omit-paths '(#px"scripts/.*\\.rkt"))
-(define license '(Apache-2.0))
+(define license 'Apache-2.0)


### PR DESCRIPTION
A single `license-id` should not be wrapped in a list.